### PR TITLE
GPII-1258: Adds Vagrant/Fedora hosts file workaround

### DIFF
--- a/fedora22-gnome3.json
+++ b/fedora22-gnome3.json
@@ -139,6 +139,7 @@
         "script/vmtool.sh",
         "script/cmtool.sh",
         "script/idiipackages.sh",
+        "script/hosts-workaround.sh",
         "script/cleanup.sh"
       ],
       "type": "shell"

--- a/script/hosts-workaround.sh
+++ b/script/hosts-workaround.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+cat <<-EOF > /usr/local/bin/edit-hosts.sh
+#!/bin/sh
+# Using config.vm.hostname to set the hostname on Fedora VMs seems to remove the string
+# "localhost" from the first line of /etc/hosts. This script reinserts it if it's missing.
+
+grep -q '127.0.0.1 localhost' /etc/hosts || sed -i 's/\(127.0.0.1\)/\1 localhost/' /etc/hosts
+EOF
+
+chmod +x /usr/local/bin/edit-hosts.sh


### PR DESCRIPTION
@waharnum, @gtirloni I would like to add this script so that it can be used by all new Fedora boxes until a permanent fix is available.