### PR TITLE
Fixed Google Chrome package version

### DIFF
--- a/script/idi-packages.sh
+++ b/script/idi-packages.sh
@@ -16,4 +16,4 @@ EOF
 ${PKG_MGR} install -y ansible curl bzip2 deltarpm gcc git kernel-devel kernel-headers make net-tools nfs-utils orca perl sqlite-devel sudo tar wget yum-utils zlib-devel
 
 # The remaining packages are GPII Framework dependencies - https://github.com/gpii/linux
-${PKG_MGR} install -y glib2-devel PackageKit-glib-devel json-glib-devel libXrandr-devel libXrender-devel libX11-devel xorg-x11-proto-devel alsa-lib-devel tuxguitar firefox google-chrome-stable
+${PKG_MGR} install -y glib2-devel PackageKit-glib-devel json-glib-devel libXrandr-devel libXrender-devel libX11-devel xorg-x11-proto-devel alsa-lib-devel tuxguitar firefox-38.0.1 google-chrome-stable-46.0.2490.86

--- a/script/idi-packages.sh
+++ b/script/idi-packages.sh
@@ -16,4 +16,4 @@ EOF
 ${PKG_MGR} install -y ansible curl bzip2 deltarpm gcc git kernel-devel kernel-headers make net-tools nfs-utils orca perl sqlite-devel sudo tar wget yum-utils zlib-devel
 
 # The remaining packages are GPII Framework dependencies - https://github.com/gpii/linux
-${PKG_MGR} install -y glib2-devel PackageKit-glib-devel json-glib-devel libXrandr-devel libXrender-devel libX11-devel xorg-x11-proto-devel alsa-lib-devel tuxguitar firefox-38.0.1 google-chrome-stable-46.0.2490.80
+${PKG_MGR} install -y glib2-devel PackageKit-glib-devel json-glib-devel libXrandr-devel libXrender-devel libX11-devel xorg-x11-proto-devel alsa-lib-devel tuxguitar firefox google-chrome-stable


### PR DESCRIPTION
I don't know if a particular version of Firefox and Chrome are needed but the 46.0.2490.80 version of Google Chrome doesn't exist in the repo. With this change the latest stable version will be installed.