### PR TITLE
Increase the timeout of dnf http requests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,27 @@
+stages:
+  - prepare
+  - build
+
+before_script:
+  - "ln -s $CACHEDIR packer_cache"
+  - "git submodule sync --recursive"
+  - "git submodule update --init --recursive"
+
+variables:
+  TMPDIR: "/datos/gitlab-ci/tmp"
+  CACHEDIR: "/datos/gitlab-ci/packer_cache"
+
+prepare_job:
+  stage: prepare
+  script:
+    - "mkdir -p $TMPDIR"
+    - "mkdir -p $CACHEDIR"
+
+build_job:
+  stage: build
+  script:
+    - "PACKER=/usr/local/bin/packer make test-virtualbox/fedora24"
+  artifacts:
+    paths:
+      - 'box/virtualbox/*.box'
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,25 +3,21 @@ stages:
   - build
 
 before_script:
-  - "ln -s $CACHEDIR packer_cache"
+  - "mkdir -p $TMPDIR"
+  - "ln -s $HOME/packer_cache packer_cache"
   - "git submodule sync --recursive"
   - "git submodule update --init --recursive"
 
 variables:
-  TMPDIR: "/datos/gitlab-ci/tmp"
-  CACHEDIR: "/datos/gitlab-ci/packer_cache"
+  TMPDIR: "$CI_PROJECT_DIR/../tmp"
 
-prepare_job:
-  stage: prepare
+build_fedora_x64_job:
+  stage: build_x64
   script:
-    - "mkdir -p $TMPDIR"
-    - "mkdir -p $CACHEDIR"
-
-build_job:
-  stage: build
-  script:
-    - "PACKER=/usr/local/bin/packer make test-virtualbox/fedora24"
-  artifacts:
-    paths:
-      - 'box/virtualbox/*.box'
+    - "make test-virtualbox/fedora25"
+    - "bash tests/test.sh"
+    - "mv box/virtualbox/*.box $HOME/boxes/"
+  tags:
+    - box_build
+  allow_failure: true
 

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,14 @@ ifndef CM_VERSION
 		CM_VERSION = latest
 	endif
 endif
-BOX_VERSION ?= $(shell cat VERSION)
+BOX_VERSION ?= $(shell date +%Y%m%d)
 DISK_SIZE ?= 10140
 SSH_USERNAME ?= vagrant
 SSH_PASSWORD ?= vagrant
 INSTALL_VAGRANT_KEY ?= true
 ISO_PATH ?= iso
 ifeq ($(CM),nocm)
-	BOX_SUFFIX := .box
+	BOX_SUFFIX := -v$(BOX_VERSION).box
 else
 	BOX_SUFFIX := -$(CM)$(CM_VERSION)-$(BOX_VERSION).box
 endif

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SSH_PASSWORD ?= vagrant
 INSTALL_VAGRANT_KEY ?= true
 ISO_PATH ?= iso
 ifeq ($(CM),nocm)
-	BOX_SUFFIX := -$(CM)-$(BOX_VERSION).box
+	BOX_SUFFIX := .box
 else
 	BOX_SUFFIX := -$(CM)$(CM_VERSION)-$(BOX_VERSION).box
 endif

--- a/Vagrantfiles/fedora25.Vagrantfile
+++ b/Vagrantfiles/fedora25.Vagrantfile
@@ -1,0 +1,14 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = "inclusivedesign/fedora24"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = true
+    vb.memory = "2048"
+    vb.customize ["modifyvm", :id, "--cpus", "2"]
+    vb.customize ["modifyvm", :id, "--vram", "128"]
+    vb.customize ["modifyvm", :id, "--accelerate3d", "on"]
+    vb.customize ["modifyvm", :id, "--audio", "null", "--audiocontroller", "ac97"]
+    vb.customize ["modifyvm", :id, "--ioapic", "on"]
+    vb.customize ["setextradata", "global", "GUI/SuppressMessages", "all"]
+  end
+end

--- a/fedora24.json
+++ b/fedora24.json
@@ -103,7 +103,7 @@
   "post-processors": [
     {
       "keep_input_artifact": false,
-      "output": "box/{{.Provider}}/inclusivedesign-fedora24.box",
+      "output": "box/{{.Provider}}/fedora24.box",
       "type": "vagrant",
       "vagrantfile_template": "Vagrantfiles/fedora24.Vagrantfile"
     }

--- a/fedora24.json
+++ b/fedora24.json
@@ -135,6 +135,7 @@
         "script/user-envs.sh",
         "script/idi-packages.sh",
         "script/browser-config.sh",
+        "script/GPII-2075.sh",
         "script/cleanup.sh"
       ],
       "type": "shell"

--- a/fedora25.json
+++ b/fedora25.json
@@ -1,0 +1,165 @@
+{
+  "builders": [
+    {
+      "boot_command": [
+        "<tab> linux text biosdevname=0 ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks-fedora25.cfg<enter><enter>"
+      ],
+      "disk_size": "{{user `disk_size`}}",
+      "guest_os_type": "fedora-64",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "http",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha256",
+      "iso_urls": [
+        "{{ user `iso_path` }}/{{ user `iso_name` }}",
+        "{{ user `iso_url` }}"
+      ],
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "vmware-iso",
+      "vm_name": "fedora25-v{{isotime \"20060102\"}}",
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "2048",
+        "numvcpus": "2"
+      }
+    },
+    {
+      "boot_command": [
+        "<tab> linux text biosdevname=0 ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks-fedora25.cfg<enter><enter>"
+      ],
+      "disk_size": "{{user `disk_size`}}",
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_os_type": "Fedora_64",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "http",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha256",
+      "iso_urls": [
+        "{{ user `iso_path` }}/{{ user `iso_name` }}",
+        "{{ user `iso_url` }}"
+      ],
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "2048"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "2"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "fedora25-v{{isotime \"20060102\"}}"
+    },
+    {
+      "boot_command": [
+        "<tab> linux text biosdevname=0 ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks-fedora25.cfg<enter><enter>"
+      ],
+      "disk_size": "{{user `disk_size`}}",
+      "guest_os_type": "fedora-core",
+      "http_directory": "http",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha256",
+      "iso_urls": [
+        "{{ user `iso_path` }}/{{ user `iso_name` }}",
+        "{{ user `iso_url` }}"
+      ],
+      "parallels_tools_flavor": "lin",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--memsize",
+          "2048"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--cpus",
+          "2"
+        ]
+      ],
+      "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
+      "vm_name": "fedora25-v{{isotime \"20060102\"}}"
+    }
+  ],
+  "post-processors": [
+    {
+      "keep_input_artifact": false,
+      "output": "box/{{.Provider}}/fedora25-v{{isotime \"20060102\"}}.box",
+      "type": "vagrant",
+      "vagrantfile_template": "Vagrantfiles/fedora25.Vagrantfile"
+    }
+  ],
+  "provisioners": [
+    {
+      "environment_vars": [
+        "CM={{user `cm`}}",
+        "CM_VERSION={{user `cm_version`}}",
+        "UPDATE={{user `update`}}",
+        "INSTALL_VAGRANT_KEY={{user `install_vagrant_key`}}",
+        "PKG_MGR={{user `pkg_mgr`}}",
+        "SSH_USERNAME={{user `ssh_username`}}",
+        "SSH_PASSWORD={{user `ssh_password`}}",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "ftp_proxy={{user `ftp_proxy`}}",
+        "rsync_proxy={{user `rsync_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "scripts": [
+        "script/sshd.sh",
+        "script/update.sh",
+        "script/vagrant.sh",
+        "script/vmtool.sh",
+        "script/cmtool.sh",
+        "script/hosts-workaround.sh",
+        "script/user-envs.sh",
+        "script/idi-packages.sh",
+        "script/browser-config.sh",
+        "script/GPII-2075.sh",
+        "script/cleanup.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "cm": "nocm",
+    "cm_version": "",
+    "disk_size": "10140",
+    "ftp_proxy": "{{env `ftp_proxy`}}",
+    "headless": "true",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "install_vagrant_key": "true",
+    "iso_checksum": "86bc3694f4938382753d1e9536f2140a6c9c1978207766340c679a89509073c7",
+    "iso_name": "Fedora-Server-netinst-x86_64-25-1.3.iso",
+    "iso_path": "iso",
+    "iso_url": "http://ftp.cica.es/fedora/linux/releases/25/Server/x86_64/iso/Fedora-Server-netinst-x86_64-25-1.3.iso",
+    "no_proxy": "{{env `no_proxy`}}",
+    "pkg_mgr": "dnf",
+    "rsync_proxy": "{{env `rsync_proxy`}}",
+    "ssh_password": "vagrant",
+    "ssh_username": "vagrant",
+    "update": "true",
+    "version": "0.1.0"
+  }
+}

--- a/http/ks-fedora24.cfg
+++ b/http/ks-fedora24.cfg
@@ -21,7 +21,8 @@ auth --enableshadow --passalgo=sha512
 timezone UTC
 
 # For missing packages
-repo --name=everything --baseurl=https://muug.ca/pub/fedora/linux/releases/24/Everything/x86_64/os/
+repo --name=everything --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+repo --name=updates --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
 
 # Optional settings
 install

--- a/http/ks-fedora25.cfg
+++ b/http/ks-fedora25.cfg
@@ -1,0 +1,107 @@
+# Fedora 24 kickstart file - ks.cfg
+#
+# For more information on kickstart syntax and commands, refer to the
+# Fedora Installation Guide:
+# http://docs.fedoraproject.org/en-US/Fedora/19/html/Installation_Guide/s1-kickstart2-options.html
+#
+# For testing, you can fire up a local http server temporarily.
+# cd to the directory where this ks.cfg file resides and run the following:
+#    $ python -m SimpleHTTPServer
+# You don't have to restart the server every time you make changes.  Python
+# will reload the file from disk every time.  As long as you save your changes
+# they will be reflected in the next HTTP download.  Then to test with
+# a PXE boot server, enter the following on the PXE boot prompt:
+#    > linux text ks=http://<your_ip>:8000/ks.cfg
+
+# Required settings
+lang en_US.UTF-8
+keyboard 'us'
+rootpw vagrant
+auth --enableshadow --passalgo=sha512
+timezone UTC
+
+user --name=vagrant --homedir=/home/vagrant --password=vagrant
+
+# For missing packages
+url --url=http://download.fedoraproject.org/pub/fedora/linux/releases/$releasever/Everything/$basearch/os/
+repo --name=everything --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+repo --name=updates --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
+
+
+# Optional settings
+install
+#cdrom
+network --bootproto=dhcp
+selinux --disabled
+firewall --disabled
+
+# Avoiding warning message on Storage device breaking automated generation
+zerombr
+
+# The following is the partition information you requested
+# Note that any partitions you deleted are not expressed
+# here so unless you clear all partitions first, this is
+# not guaranteed to work
+clearpart --all --initlabel
+services --enabled sshd
+
+autopart
+reboot
+
+%packages --excludedocs
+@core
+@base-x
+@fonts
+@multimedia
+@hardware-support
+@workstation-product
+@gnome-desktop 
+%end
+
+%post
+# Set systemlctl default target to graphical
+systemctl set-default graphical.target
+
+# Set up Ansible so it can be used to provision the VM locally
+sed -i 's/^transport.*/transport = local/g' /etc/ansible/ansible.cfg
+sed -i 's/^#host_key_checking.*$/host_key_checking\ \=\ False/g' /etc/ansible/ansible.cfg
+cat <<-EOF > /etc/ansible/hosts
+[local]
+localhost
+EOF
+
+# Give Vagrant user permission to sudo.
+echo 'Defaults:vagrant !requiretty' > /etc/sudoers.d/vagrant
+echo '%vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/vagrant
+chmod 440 /etc/sudoers.d/vagrant
+
+# Allow the vagrant user to autologin and also disable Wayland
+# https://www.maketecheasier.com/fix-wayland-gdm-issue-fedora/
+cat <<-EOF > /etc/gdm/custom.conf
+[daemon]
+AutomaticLoginEnable=true
+AutomaticLogin=vagrant
+WaylandEnable=false
+EOF
+
+# Disable gnome-initial-setup
+mkdir /home/vagrant/.config
+touch /home/vagrant/.config/gnome-initial-setup-done
+
+# Disable screensaver
+mkdir -p /home/vagrant/.config/autostart
+cat <<-EOF > /home/vagrant/.config/autostart/disable-screensaver.desktop
+[Desktop Entry]
+Type=Application
+Name=DisableScreensaver
+Comment=Disable screensaver
+Exec=gsettings set org.gnome.desktop.session idle-delay 0
+Terminal=false
+NoDisplay=true
+X-GNOME-Autostart-enabled=true
+EOF
+
+# Fix ownership of all files in /home/vagrant
+chown -R vagrant:vagrant /home/vagrant /home/vagrant/.[^.]*
+
+%end

--- a/script/GPII-2075.sh
+++ b/script/GPII-2075.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script is used to add a dnf workaround described at
+# https://issues.gpii.net/browse/GPII-2075
+
+sed -i '/\[main\]/ a timeout=10000' /etc/dnf/dnf.conf
+

--- a/script/cleanup.sh
+++ b/script/cleanup.sh
@@ -3,6 +3,9 @@
 echo "==> Cleaning up ${PKG_MGR} cache of metadata and packages to save space"
 ${PKG_MGR} -y clean all
 
+echo "==> Fixing the vagrant user permissions"
+chown vagrant:vagrant /home/vagrant -R
+
 rm -rf /tmp/*
 
 echo "==> Zeroing out empty area to save space in the final image"


### PR DESCRIPTION
Closes https://issues.gpii.net/browse/GPII-2075

> This Universal CI job run shows a dnf issue:
> 
> `dnf.exceptions.RepoError: Failed to synchronize cache for repo 'updates'`
> 
> More details can be found in the following bug report:
> https://bugzilla.redhat.com/show_bug.cgi?id=1192524
> 
> For now it looks like the Fedora box will require the `timeout=1000` workaround.
