### PR TITLE
Increase size from 10GiB to 15GiB

### DIFF
--- a/fedora26.json
+++ b/fedora26.json
@@ -145,7 +145,7 @@
   "variables": {
     "cm": "nocm",
     "cm_version": "",
-    "disk_size": "10140",
+    "disk_size": "15360",
     "ftp_proxy": "{{env `ftp_proxy`}}",
     "headless": "true",
     "http_proxy": "{{env `http_proxy`}}",


### PR DESCRIPTION
This is a possible fix for the issue Cindy [reported](https://lists.gpii.net/pipermail/infrastructure/2017-October/000123.html).

Vanilla F26:
```
Filesystem               Size  Used Avail Use% Mounted on
/dev/mapper/fedora-root  7.9G  5.5G  2.5G  69% /
```

GPII/universal after provisioning:
```
Filesystem                   Size  Used Avail Use% Mounted on
/dev/mapper/fedora-root      7.9G  6.5G  1.5G  82% /
```

GPII/universal after Browser tests:
```
Filesystem                   Size  Used Avail Use% Mounted on
/dev/mapper/fedora-root      7.9G  7.2G  761M  91% /
```

GPII/universal after Node tests:
```
Filesystem                   Size  Used Avail Use% Mounted on
/dev/mapper/fedora-root      7.9G  7.2G  761M  91% /
```

GPII/universal after Production tests (builds Docker image, fetches CouchDB image, etc):
```
Filesystem                   Size  Used Avail Use% Mounted on
/dev/mapper/fedora-root      7.9G  7.8G  124M  99% /
```