### PR TITLE
INFRA-147 - Switch from Docker 1.13 to Docker CE

### DIFF
--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -eux
 
-dnf install -y docker
+dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+dnf install -y docker-ce
 systemctl enable docker
 groupadd docker
 usermod -a -G docker vagrant


### PR DESCRIPTION
This is necessary to support [multi-stage](https://docs.docker.com/develop/develop-images/multistage-build/) builds which can simplify CI/CD.

This doesn't add an 'exclude=docker*' to yum's configuration because the docker-ce package by itself will not let the docker package install (due to package conflict).

Tested with GPII/universal containers.

```
[vagrant@universal universal]$ docker version
Client:
 Version:	17.12.1-ce
 API version:	1.35
 Go version:	go1.9.4
 Git commit:	7390fc6
 Built:	Tue Feb 27 22:20:00 2018
 OS/Arch:	linux/amd64

Server:
 Engine:
  Version:	17.12.1-ce
  API version:	1.35 (minimum version 1.12)
  Go version:	go1.9.4
  Git commit:	7390fc6
  Built:	Tue Feb 27 22:22:34 2018
  OS/Arch:	linux/amd64
  Experimental:	false
```